### PR TITLE
Fix URL for use with newer Keycloak versions

### DIFF
--- a/ch2/backend/keycloak.json
+++ b/ch2/backend/keycloak.json
@@ -1,6 +1,6 @@
 {
   "realm": "myrealm",
   "bearer-only": true,
-  "auth-server-url": "${env.KC_URL:http://localhost:8080/auth}",
+  "auth-server-url": "${env.KC_URL:http://localhost:8080}",
   "resource": "service-nodejs"
 }

--- a/ch2/frontend/app.js
+++ b/ch2/frontend/app.js
@@ -2,7 +2,7 @@ var express = require('express');
 var app = express();
 var stringReplace = require('string-replace-middleware');
 
-var KC_URL = process.env.KC_URL || "http://localhost:8080/auth";
+var KC_URL = process.env.KC_URL || "http://localhost:8080";
 var SERVICE_URL = process.env.SERVICE_URL || "http://localhost:3000/secured";
 
 app.use(stringReplace({


### PR DESCRIPTION
Newer versions do not use /auth anymore.